### PR TITLE
Make absolute pathing opt-in rather than the default

### DIFF
--- a/src/lein_modules/inheritance.clj
+++ b/src/lein_modules/inheritance.clj
@@ -20,11 +20,9 @@
   (->> (for [k (keys m)
              :when (.contains (name k) "-paths")]
          [k (mapv (fn [p]
-                    (if (string? p)
-                      (let [pf (io/file p)]
-                        (.getAbsolutePath
-                         (if-not (.isAbsolute pf)
-                           (io/file root p) pf)))
+                    (if (and (string? p) (.startsWith p "//"))
+                      (.getAbsolutePath
+                       (io/file root (.replaceFirst p "//" "")))
                       p))
                   (get m k))])
        (into {})


### PR DESCRIPTION
Revisits the decision of #4. Normally, all leiningen paths are interpreted as being relative. Upstream lein-modules does nothing to change this behavior. #4 was an attempt to make lein-modules more predictable when inheriting directories between parent/child projects.

The problem with that changeset is that it clobbered lein(-modules)'s default behavior without giving an escape hatch. It can be convenient for instance to state in a parent project that all children should include their `test/` trees in an uberjar without having to provide machinery for interpreting that path in a child-dependent manner.

Adding an escape hatch, for instance supporting `./` as an "escape" prefix, significantly adds complexity while preserving the mistake of changing lein(-modules)'s default behavior. This changeset instead adds support for Pants/Buck style `//` prefixed paths to be interpreted as being absolute with respect to the project.clj in which they occur. This approach restores the lein(-modules) default behavior, while providing an escape hatch for inheriting absolute paths.